### PR TITLE
fix: no type given equals any object

### DIFF
--- a/internal/generator/ts_generator_test.go
+++ b/internal/generator/ts_generator_test.go
@@ -24,6 +24,11 @@ func TestTSGeneration(t *testing.T) {
 	}
 
 	expected := `
+export interface DynamicPayload {
+  data: any;
+  info?: any | null;
+}
+
 export interface LoginResponse {
   token: string;
 }

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -15,6 +15,20 @@
   },
   "components": {
     "schemas": {
+      "DynamicPayload": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+            "data": {
+              "type": "object"
+            },
+          "info": {
+            "nullable": true
+          }
+        }
+      },
       "LoginResponse": {
         "type": "object",
         "required": [


### PR DESCRIPTION
- fixes a bug, where the generator produces invalid typescript definitions when there is no type given for a property of an object, or, when the properties type is only object without a schema ref