### PR TITLE
feat/multipart support

### DIFF
--- a/internal/generator/ts_generator.go
+++ b/internal/generator/ts_generator.go
@@ -229,7 +229,7 @@ func parseSchema(name string, schema *openapi3.Schema) Model {
 			}
 
 			if field.Value.Format == "binary" {
-				f.Type = "Blob"
+				f.Type = "string | Blob | File"
 			}
 
 		}

--- a/internal/generator/ts_generator.go
+++ b/internal/generator/ts_generator.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const FormDataSuffix = "FormData"
+
 func (g *generator) generateTypescriptTypes() error {
 	color.Set(color.FgHiBlack)
 	g.s.Suffix = " Generating types page"
@@ -79,97 +81,44 @@ func generateTypes(doc *openapi3.T, outputPath string) error {
 			continue
 		}
 
-		typeString := schema.Type
-
-		if typeString == "" {
-			typeString = "object"
-		}
-
-		model := Model{
-			Name:   name,
-			Type:   typeString,
-			IsEnum: false,
-			Fields: make([]Field, 0),
-		}
-
-		if schema.Enum != nil {
-			model.IsEnum = true
-			model.Values = schema.Enum
-			models = append(models, model)
-			continue
-		}
-
-		var requiredFields []string
-		if schema.Required != nil {
-			requiredFields = schema.Required
-		}
-
-		for fieldName, field := range ref.Value.Properties {
-			var f Field
-
-			switch field.Value.Type {
-			case "array":
-				f = Field{
-					Name:     fieldName,
-					Nullable: field.Value.Nullable,
-					Optional: true,
-				}
-
-				if field.Value.Items.Ref != "" {
-					f.Type = parseRefName(field.Value.Items.Ref) + "[]"
-				} else {
-					f.Type = swaggerTypeToTypescriptType[field.Value.Items.Value.Type] + "[]"
-				}
-			case "object":
-				fieldType := "any"
-
-				if field.Ref != "" {
-					fieldType = parseRefName(field.Ref)
-				}
-
-				f = Field{
-					Name:     fieldName,
-					Type:     fieldType,
-					Nullable: field.Value.Nullable,
-					Optional: true,
-				}
-			default:
-				fieldType := field.Value.Type
-
-				if fieldType == "" {
-					fieldType = "object"
-				}
-
-				f = Field{
-					Name:     fieldName,
-					Type:     swaggerTypeToTypescriptType[fieldType],
-					Nullable: field.Value.Nullable,
-					Optional: true,
-				}
-
-				if field.Ref != "" {
-					f.Type = parseRefName(field.Ref)
-				}
-
-			}
-
-			for _, requiredField := range requiredFields {
-				if requiredField == fieldName {
-					f.Optional = false
-					break
-				}
-			}
-
-			model.Fields = append(model.Fields, f)
-
-		}
-
-		// sort fields by name
-		sort.Slice(model.Fields, func(i, j int) bool {
-			return model.Fields[i].Name < model.Fields[j].Name
-		})
+		model := parseSchema(name, schema)
 
 		models = append(models, model)
+	}
+
+	// add form data from unmapped schemas from paths
+	for _, path := range doc.Paths {
+
+		if path.Post != nil {
+			info := path.Post.RequestBody
+
+			model, err := handleFormDataRequestBody(path.Post.OperationID+FormDataSuffix, info)
+
+			if err == nil {
+				models = append(models, model)
+			}
+		}
+
+		if path.Put != nil {
+			info := path.Put.RequestBody
+
+			model, err := handleFormDataRequestBody(path.Put.OperationID+FormDataSuffix, info)
+
+			if err == nil {
+				models = append(models, model)
+			}
+		}
+
+		if path.Patch != nil {
+			info := path.Patch.RequestBody
+
+			model, err := handleFormDataRequestBody(path.Patch.OperationID+FormDataSuffix, info)
+
+			if err == nil {
+				models = append(models, model)
+			}
+		}
+
 	}
 
 	sort.Slice(models, func(i, j int) bool {
@@ -205,4 +154,124 @@ func generateTypes(doc *openapi3.T, outputPath string) error {
 	}
 
 	return nil
+}
+
+func parseSchema(name string, schema *openapi3.Schema) Model {
+	typeString := schema.Type
+
+	if typeString == "" {
+		typeString = "object"
+	}
+
+	model := Model{
+		Name:   name,
+		Type:   typeString,
+		IsEnum: false,
+		Fields: make([]Field, 0),
+	}
+
+	if schema.Enum != nil {
+		model.IsEnum = true
+		model.Values = schema.Enum
+		return model
+	}
+
+	var requiredFields []string
+	if schema.Required != nil {
+		requiredFields = schema.Required
+	}
+
+	for fieldName, field := range schema.Properties {
+		var f Field
+
+		switch field.Value.Type {
+		case "array":
+			f = Field{
+				Name:     fieldName,
+				Nullable: field.Value.Nullable,
+				Optional: true,
+			}
+
+			if field.Value.Items.Ref != "" {
+				f.Type = parseRefName(field.Value.Items.Ref) + "[]"
+			} else {
+				f.Type = swaggerTypeToTypescriptType[field.Value.Items.Value.Type] + "[]"
+			}
+		case "object":
+			fieldType := "any"
+
+			if field.Ref != "" {
+				fieldType = parseRefName(field.Ref)
+			}
+
+			f = Field{
+				Name:     fieldName,
+				Type:     fieldType,
+				Nullable: field.Value.Nullable,
+				Optional: true,
+			}
+		default:
+			fieldType := field.Value.Type
+
+			if fieldType == "" {
+				fieldType = "object"
+			}
+
+			f = Field{
+				Name:     fieldName,
+				Type:     swaggerTypeToTypescriptType[fieldType],
+				Nullable: field.Value.Nullable,
+				Optional: true,
+			}
+
+			if field.Ref != "" {
+				f.Type = parseRefName(field.Ref)
+			}
+
+			if field.Value.Format == "binary" {
+				f.Type = "Blob"
+			}
+
+		}
+
+		for _, requiredField := range requiredFields {
+			if requiredField == fieldName {
+				f.Optional = false
+				break
+			}
+		}
+
+		model.Fields = append(model.Fields, f)
+	}
+
+	// sort fields by name
+	sort.Slice(model.Fields, func(i, j int) bool {
+		return model.Fields[i].Name < model.Fields[j].Name
+	})
+
+	return model
+}
+
+func handleFormDataRequestBody(name string, body *openapi3.RequestBodyRef) (Model, error) {
+	if body == nil || body.Value == nil || body.Ref != "" {
+		return Model{}, fmt.Errorf("no form data body found")
+	}
+
+	formDataBody, ok := body.Value.Content["multipart/form-data"]
+
+	if !ok {
+		return Model{}, fmt.Errorf("no form data body found")
+	}
+
+	if formDataBody != nil && formDataBody.Schema != nil {
+		schema := formDataBody.Schema
+
+		if schema.Ref != "" {
+			return Model{}, fmt.Errorf("no form data body found")
+		}
+
+		return parseSchema(name, schema.Value), nil
+	}
+
+	return Model{}, fmt.Errorf("no form data body found")
 }

--- a/internal/generator/ts_generator_test.go
+++ b/internal/generator/ts_generator_test.go
@@ -30,7 +30,7 @@ export interface DynamicPayload {
 }
 
 export interface LoginFormData {
-  certificate: Blob;
+  certificate: string | Blob | File;
   email: string;
   password: string;
 }

--- a/internal/generator/ts_generator_test.go
+++ b/internal/generator/ts_generator_test.go
@@ -29,6 +29,12 @@ export interface DynamicPayload {
   info?: any | null;
 }
 
+export interface LoginFormData {
+  certificate: Blob;
+  email: string;
+  password: string;
+}
+
 export interface LoginResponse {
   token: string;
 }

--- a/internal/templates/types.ts.tmpl
+++ b/internal/templates/types.ts.tmpl
@@ -7,4 +7,23 @@ export enum <% .Name %> {<% range .Values %>
 export interface <% .Name %> {<% range .Fields %>
   <% .Name %><% if .Optional %>?<% end %>: <% .Type %><% if .Nullable %> | null<% end %>;<% end %>
 }
-<% end %><% end %><% end %>
+<% end %><% end %>
+function buildFormData(formData: FormData, data: any, parentKey?: string) {
+  if (data && typeof data === 'object' && !(data instanceof Date) && !(data instanceof File) && !(data instanceof Blob)) {
+    Object.keys(data).forEach(key => {
+      buildFormData(formData, data[key], parentKey ? `${parentKey}[${key}]` : key);
+    });
+  } else {
+    const value = data == null ? '' : data;
+
+    formData.append(parentKey, value);
+  }
+}
+
+export function convertToFormData<T extends object>(data: T) {
+  const formData = new FormData();
+
+  buildFormData(formData, data);
+
+  return formData;
+}<% end %>

--- a/testdata/test.json
+++ b/testdata/test.json
@@ -11,7 +11,100 @@
     }
   ],
   "paths": {
-
+    "/v1/auth/login": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": " (Auth)",
+        "operationId": "Login",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "email",
+                  "password",
+                  "certificate"
+                ],
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "maxLength": 150,
+                    "type": "string"
+                  },
+                  "password": {
+                    "maxLength": 253,
+                    "type": "string"
+                  },
+                  "certificate": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "bezeichnung": {
+                  "style": "form"
+                },
+                "frontendBrandColor": {
+                  "style": "form"
+                },
+                "mailLogoUrl": {
+                  "style": "form"
+                },
+                "mailHost": {
+                  "style": "form"
+                },
+                "mailPort": {
+                  "style": "form"
+                },
+                "mailReplyTo": {
+                  "style": "form"
+                },
+                "mailFrom": {
+                  "style": "form"
+                },
+                "mailFromName": {
+                  "style": "form"
+                },
+                "mailHTMLSignature": {
+                  "style": "form"
+                },
+                "mailUser": {
+                  "style": "form"
+                },
+                "mailPassword": {
+                  "style": "form"
+                },
+                "logo": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              },
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+              "ADMIN"
+            ]
+          }
+        ]
+      }
+    }
   },
   "components": {
     "schemas": {


### PR DESCRIPTION
- enable generation of formdata objects from path request bodies
- includes a small conversion helper function exported as `convertToFormData` that takes an object as a parameter and returns a `FormData` object

Closes #13 